### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/kinddata/04f08fff-7da2-4ae6-ba46-9d7e525c8ec5/59f19a5f-1ca4-481e-ba07-3a5b223d0313/_apis/work/boardbadge/f99dab3c-7824-4548-aed1-08aa9cdf1c85)](https://dev.azure.com/kinddata/04f08fff-7da2-4ae6-ba46-9d7e525c8ec5/_boards/board/t/59f19a5f-1ca4-481e-ba07-3a5b223d0313/Microsoft.RequirementCategory)
 # TimesTablePrint
 A single HTML file that prints a practise times table question sheet for the kids


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/kinddata/04f08fff-7da2-4ae6-ba46-9d7e525c8ec5/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.